### PR TITLE
Fix mac m1 display problem

### DIFF
--- a/src/components/Aria2Toast.vue
+++ b/src/components/Aria2Toast.vue
@@ -46,7 +46,11 @@ defineExpose({ open })
   border-radius: 8px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   font-size: 14px;
-  z-index: 9999;
+  /* 修复：macOS m1上toast不显示在最上层的问题
+    问题根源：AiraConfigDialog.vue和AriaDownloadDialog.vue中
+    .dialog类样式下"z-index"值均设置为10000
+  */
+  z-index: 10001;
   min-width: 300px;
   text-align: center;
   display: flex;

--- a/src/components/AriaDownloadDialog.vue
+++ b/src/components/AriaDownloadDialog.vue
@@ -432,6 +432,12 @@ const push = async () => {
   backdrop-filter: blur(10px);
   border: 1px solid rgba(255, 255, 255, 0.2);
   animation: dialogFadeIn 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+
+  /* 修改对话框样式 */
+  display: flex;
+  flex-direction: column;
+  max-height: 90vh;
+  overflow: hidden; /* 防止整个对话框滚动 */
 }
 
 @keyframes dialogFadeIn {
@@ -517,7 +523,11 @@ const push = async () => {
   align-items: center;
   margin-bottom: 20px;
   padding: 16px 20px;
-  background: linear-gradient(135deg, rgba(99, 102, 241, 0.05) 0%, rgba(168, 85, 247, 0.05) 100%);
+  background: linear-gradient(
+    135deg,
+    rgba(99, 102, 241, 0.05) 0%,
+    rgba(168, 85, 247, 0.05) 100%
+  );
   border-radius: 12px;
   border: 1px solid rgba(99, 102, 241, 0.1);
 }
@@ -593,7 +603,12 @@ const push = async () => {
 /* 文件列表容器 */
 .movies {
   margin-top: 16px;
-  height: 400px;
+
+  /* 修改文件列表容器 */
+  flex: 1; /* 关键修改：占据剩余空间 */
+  min-height: 200px; /* 最小高度保障 */
+  /* height: 400px; */
+
   overflow-y: auto;
   border: 2px solid #f1f5f9;
   border-radius: 16px;
@@ -641,7 +656,11 @@ const push = async () => {
 }
 
 .movies li:hover {
-  background: linear-gradient(135deg, rgba(99, 102, 241, 0.05) 0%, rgba(168, 85, 247, 0.05) 100%);
+  background: linear-gradient(
+    135deg,
+    rgba(99, 102, 241, 0.05) 0%,
+    rgba(168, 85, 247, 0.05) 100%
+  );
   transform: translateX(4px);
 }
 
@@ -674,19 +693,28 @@ const push = async () => {
 
 /* 底部操作区 */
 .footer {
-  margin-top: 24px;
+  /* margin-top: 24px; */
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: 16px;
   padding-top: 20px;
   border-top: 1px solid rgba(226, 232, 240, 0.6);
+
+  /* 确保底部区域始终可见 */
+  flex-shrink: 0; /* 防止被压缩 */
+  margin-top: auto; /* 自动推到底部 */
 }
 
 @media (max-width: 480px) {
+  .movies {
+    min-height: 150px; /* 移动端适当减小最小高度 */
+  }
+
   .footer {
     flex-direction: column;
     gap: 12px;
+    padding: 16px 0 0;
   }
 }
 

--- a/src/components/AriaDownloadDialog.vue
+++ b/src/components/AriaDownloadDialog.vue
@@ -787,6 +787,32 @@ const push = async () => {
   }
 }
 
+/* 新增：修复移动端显示器顶部工具栏布局问题 */
+@media (max-width: 768px) {
+  .toolbar {
+    flex-direction: column; /* 工具栏整体改为垂直布局 */
+    gap: 12px;
+    align-items: stretch; /* 子元素拉伸填充宽度 */
+  }
+
+  .sort-options {
+    display: flex;
+    flex-direction: column; /* 关键：排序选项垂直排列 */
+    gap: 8px; /* 增加垂直间距 */
+    width: 100%; /* 确保充分利用可用宽度 */
+  }
+
+  .sort-options label[for="sort-by"] {
+    margin-bottom: 4px; /* 给"排序方式"标签一点下边距 */
+    font-size: 14px; /* 可选：调整字体大小适应小屏幕 */
+  }
+
+  .sort-options select {
+    width: 100%; /* 下拉框宽度填满容器 */
+    box-sizing: border-box; /* 确保padding和border包含在宽度内 */
+  }
+}
+
 /* aria2连接状态样式 */
 .connection-status {
   display: flex;


### PR DESCRIPTION
修复了macOS M1下`edge`和`Firefox development`浏览器显示下载页面的问题

- 1. 处理macOS M1下下载页面底部配置和下载按钮无法正常显示的问题以及toast提示信息被遮挡的问题
处理前效果：
<img width="2880" height="1732" alt="p1" src="https://github.com/user-attachments/assets/dfadd27e-3bf2-4e40-9fb1-acec09adefec" />
处理后效果
<img width="2880" height="1800" alt="fix3" src="https://github.com/user-attachments/assets/314384c5-0abf-44d8-b203-bd688589b630" />

- 2.  处理移动端顶部工具栏布局问题
处理前效果：
<img width="2864" height="1408" alt="pikpak-helper-plus-sortbox-problem" src="https://github.com/user-attachments/assets/ce8a2e99-b315-4d28-9086-ed1c0b00746b" />
处理后效果：
<img width="2864" height="1408" alt="fix2" src="https://github.com/user-attachments/assets/9124f515-29f3-4e30-b5a5-484efefa7c5e" />

因为我之前项目开了`Prettier`的关系，保存的时候导致某些css，js，vue模版代码被格式化了